### PR TITLE
Safeguard against elements not having a parent

### DIFF
--- a/lib/getLineHeight.js
+++ b/lib/getLineHeight.js
@@ -5,7 +5,8 @@ module.exports = (css, opts) => {
   css.walkDecls((decl) => {
     // Check if the declaration is not inside the a print media query
     // if is the root selector
-    if (decl.parent.parent.params !== 'print' &&
+    if (decl.parent.parent &&
+        decl.parent.parent.params !== 'print' &&
         decl.parent.selector === opts.rootSelector &&
         (decl.prop === 'font' || decl.prop === 'line-height')){
 


### PR DESCRIPTION
Ensure a declaration has a parent before trying to access properties of said parent. The conditional currently throws an exception of `Cannot read property 'params' of undefined` if there isn't one.